### PR TITLE
[docs]: update deployment URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The server will start at `http://localhost:5000`.
 ## **Deployment**
 The API is deployed on **Render.com**. You can access it at:
 ```
-https://<your-render-app-url>
+https://thescribe.onrender.com
 ```
 
 ---


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the URL for the deployed API to the correct address.

* [`README.md`]: Updated the deployment URL to `https://thescribe.onrender.com`.